### PR TITLE
Regex grep property lookup

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8219,6 +8219,7 @@ function execCallback(resolve, reject, error, stdout, stderr, cmd) {
     const msg = `No results found with: ${cmd}`;
     reject(msg);
   }
+  console.log(stdout);
   const outParts = stdout.split(':');
   if (outParts.length < 2 || outParts[1] === undefined || !outParts[1] instanceof String) {
     const msg = `Value not set for property found with: ${cmd}`;

--- a/dist/index.js
+++ b/dist/index.js
@@ -8219,7 +8219,6 @@ function execCallback(resolve, reject, error, stdout, stderr, cmd) {
     const msg = `No results found with: ${cmd}`;
     reject(msg);
   }
-  console.log(stdout);
   const outParts = stdout.split(':');
   if (outParts.length < 2 || outParts[1] === undefined || !outParts[1] instanceof String) {
     const msg = `Value not set for property found with: ${cmd}`;

--- a/dist/index.js
+++ b/dist/index.js
@@ -8128,7 +8128,7 @@ try {
   const orgName = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('organization');
   const accessToken = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('access-token');
   const found = await versionClient.isVersionPresent(packageName, version, orgName, accessToken);
-  printFoundOutput(found);
+  printFoundOutput(found, version);
   const changed = !found;
 
   _actions_core__WEBPACK_IMPORTED_MODULE_0__.setOutput("changed", changed);

--- a/dist/index.js
+++ b/dist/index.js
@@ -8169,7 +8169,7 @@ class PropertyCmdBuilder {
     if (isWindows) {
       return `./gradlew properties | Select-String '${propName}:'`;
     } else {
-      return `./gradlew properties | grep '${propName}:'`;
+      return `./gradlew properties | grep -e '^${propName}:*'`;
     }
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -11,7 +11,7 @@ try {
   const orgName = core.getInput('organization');
   const accessToken = core.getInput('access-token');
   const found = await versionClient.isVersionPresent(packageName, version, orgName, accessToken);
-  printFoundOutput(found);
+  printFoundOutput(found, version);
   const changed = !found;
 
   core.setOutput("changed", changed);

--- a/src/property-cmd-builder.js
+++ b/src/property-cmd-builder.js
@@ -5,7 +5,7 @@ export default class PropertyCmdBuilder {
     if (isWindows) {
       return `./gradlew properties | Select-String '${propName}:'`;
     } else {
-      return `./gradlew properties | grep '${propName}:'`;
+      return `./gradlew properties | grep -e '^${propName}:*'`;
     }
   }
 

--- a/src/property-extractor.js
+++ b/src/property-extractor.js
@@ -38,7 +38,6 @@ function execCallback(resolve, reject, error, stdout, stderr, cmd) {
     const msg = `No results found with: ${cmd}`;
     reject(msg);
   }
-  console.log(stdout);
   const outParts = stdout.split(':');
   if (outParts.length < 2 || outParts[1] === undefined || !outParts[1] instanceof String) {
     const msg = `Value not set for property found with: ${cmd}`;

--- a/src/property-extractor.js
+++ b/src/property-extractor.js
@@ -38,6 +38,7 @@ function execCallback(resolve, reject, error, stdout, stderr, cmd) {
     const msg = `No results found with: ${cmd}`;
     reject(msg);
   }
+  console.log(stdout);
   const outParts = stdout.split(':');
   if (outParts.length < 2 || outParts[1] === undefined || !outParts[1] instanceof String) {
     const msg = `Value not set for property found with: ${cmd}`;


### PR DESCRIPTION
Limit chance of multiple matches for property by using grep regex.
Correct version found output.